### PR TITLE
Add lantern flame and flicker, fix some bugs

### DIFF
--- a/OctJam/Config/DefaultEngine.ini
+++ b/OctJam/Config/DefaultEngine.ini
@@ -103,5 +103,5 @@ MinDeltaVelocityForHitEvents=0.000000
 ChaosSettings=(DefaultThreadingModel=TaskGraph,DedicatedThreadTickMode=VariableCappedWithTarget,DedicatedThreadBufferMode=Double)
 
 [/Script/Engine.UserInterfaceSettings]
-UIScaleRule=ScaleToFit
+UIScaleRule=ShortestSide
 

--- a/OctJam/Config/DefaultEngine.ini
+++ b/OctJam/Config/DefaultEngine.ini
@@ -102,3 +102,6 @@ DefaultBroadphaseSettings=(bUseMBPOnClient=False,bUseMBPOnServer=False,bUseMBPOu
 MinDeltaVelocityForHitEvents=0.000000
 ChaosSettings=(DefaultThreadingModel=TaskGraph,DedicatedThreadTickMode=VariableCappedWithTarget,DedicatedThreadBufferMode=Double)
 
+[/Script/Engine.UserInterfaceSettings]
+UIScaleRule=ScaleToFit
+

--- a/OctJam/Config/DefaultGameUserSettings.ini
+++ b/OctJam/Config/DefaultGameUserSettings.ini
@@ -1,0 +1,12 @@
+[/Script/Engine.GameUserSettings]
+bUseVSync=False
+ResolutionSizeX=0
+ResolutionSizeY=0
+LastUserConfirmedResolutionSizeX=0
+LastUserConfirmedResolutionSizeY=0
+WindowPosX=-1
+WindowPosY=-1
+FullscreenMode=2
+LastConfirmedFullscreenMode=2
+PreferredFullscreenMode=2
+Version=5

--- a/OctJam/Content/Maps/Level1.umap
+++ b/OctJam/Content/Maps/Level1.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:102be6e79dcae7c1b923502de4fec3100005651566087f55efef40a0ba1cd6cf
-size 6650941
+oid sha256:bec0881cadf9905bc1d8c5aefe237d2508cab42ebff108c30a5833fe2982aed7
+size 6649449

--- a/OctJam/Content/Maps/StartMenuLevel.umap
+++ b/OctJam/Content/Maps/StartMenuLevel.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5e478923ff58704e5191b563f0f5e5364effd60a1f8da968e6238b04ffa963fb
-size 57090
+oid sha256:21929820cbc9fb48684b5f7e1904b06cc2398812ecc943d6ba27ead1efbd1240
+size 58141

--- a/OctJam/Content/OctJam/Blueprints/Characters/BP_MainCharacter.uasset
+++ b/OctJam/Content/OctJam/Blueprints/Characters/BP_MainCharacter.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:219d02a59cdcd853a3ddf0582b8bb6101fbae321b8a34b551dc62b2a5baea167
-size 1387457
+oid sha256:68993a8ce69a6b11be328700d082c4441b66e0e4b9c8d5ac836c61091eef5bde
+size 1255710

--- a/OctJam/Content/OctJam/Blueprints/UI/WBP_Credits.uasset
+++ b/OctJam/Content/OctJam/Blueprints/UI/WBP_Credits.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0c64c61bdcc0de590abf9cf5a33ff49176020a79c6384f9c582d5a6d2530d7d9
-size 67636
+oid sha256:785ffdd3732a161232df49e4cd873983373f04c7dd45dc821e2bc41b6e6e79dc
+size 71131

--- a/OctJam/Content/OctJam/Blueprints/UI/WBP_PauseMenu.uasset
+++ b/OctJam/Content/OctJam/Blueprints/UI/WBP_PauseMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2ef03ca7869bf408cf210b23f95612ccdc7916d49688db0b0a0b1ac8d464bc89
-size 409930
+oid sha256:a7716b214d97738859e33984ae479d7e37f95015c1cb7b7c9f684070e3c877f6
+size 410204

--- a/OctJam/Content/OctJam/Blueprints/UI/WBP_PauseMenu.uasset
+++ b/OctJam/Content/OctJam/Blueprints/UI/WBP_PauseMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7716b214d97738859e33984ae479d7e37f95015c1cb7b7c9f684070e3c877f6
-size 410204
+oid sha256:db17aebf7b1bf6c817d937711d8853afc146079e6a08ae5622bef1c3967e0fbf
+size 410861

--- a/OctJam/Content/OctJam/Blueprints/UI/WBP_StartMenu.uasset
+++ b/OctJam/Content/OctJam/Blueprints/UI/WBP_StartMenu.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5f8df363cd008359798cc4abb8a6ea35ea5725a0a6641955212d6c83574833b
-size 323724
+oid sha256:7bffffbeb8ac2ea960dfff78c4138b6b2d5131a3eea8c32e175cc92ef819ee05
+size 324889

--- a/OctJam/Content/OctJam/FX/NS_FlickeringLight.uasset
+++ b/OctJam/Content/OctJam/FX/NS_FlickeringLight.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5d09767ec65b763da8b9716a8d5b7a68ca494dad277469082938aa4b2d9f3a66
+size 1760851

--- a/OctJam/Content/OctJam/Materials/M_FlickeringLightFunction.uasset
+++ b/OctJam/Content/OctJam/Materials/M_FlickeringLightFunction.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5960bf87020d66d46334892fc37221b7a77c76d5c617e15cf7d76b2822e75086
+size 11928

--- a/OctJam/Source/OctJam/Private/Character/MainCharacter.cpp
+++ b/OctJam/Source/OctJam/Private/Character/MainCharacter.cpp
@@ -164,6 +164,7 @@ void AMainCharacter::AdjustLightBasedOnMapLevel()
 
   // Set the new attenuation radius for the point light
   PointLight->SetAttenuationRadius(newRadius);
+  PointLight->SetIntensity(newIntensity);
 }
 
 void AMainCharacter::UpdateCharacterDirection()
@@ -250,17 +251,19 @@ void AMainCharacter::UpdateLightPosition()
   switch (DirectionToUse)
   {
   case ELastMoveDirection::LMD_Forward:
+    NewLightPosition = FVector(-50.0f, 30.0f, 30.0f);
+    break;
   case ELastMoveDirection::LMD_Backward:
-    NewLightPosition = FVector(0.0f, 0.0f, 250.0f);
+    NewLightPosition = FVector(-35.0f, -20.0f, 30.0f);
     break;
   case ELastMoveDirection::LMD_Left:
-    NewLightPosition = FVector(0.0f, -100.0f, 250.0f);
+    NewLightPosition = FVector(-30.0f, -25.0f, 30.0f);
     break;
   case ELastMoveDirection::LMD_Right:
-    NewLightPosition = FVector(0.0f, 100.0f, 250.0f);
+    NewLightPosition = FVector(-40.0f, 10.0f, 30.0f);
     break;
   default:
-    NewLightPosition = FVector(0.0f, 0.0f, 250.0f);
+    NewLightPosition = FVector(-50.0f, 30.0f, 30.0f);
     break;
   }
 

--- a/OctJam/Source/OctJam/Public/Character/MainCharacter.h
+++ b/OctJam/Source/OctJam/Public/Character/MainCharacter.h
@@ -49,6 +49,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Light")
 	void AdjustLightBasedOnMapLevel();
 
+	UPROPERTY(VisibleAnywhere, BlueprintReadWrite, Category = "Light")
+	UPointLightComponent* PointLight;
+
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Sprite")
 	UPaperFlipbookComponent* CharacterSprite;
 
@@ -128,9 +131,6 @@ private:
 
 	UPROPERTY(VisibleAnywhere, Category = "Camera")
 	UCameraComponent* FollowCamera;
-
-	UPROPERTY(VisibleAnywhere)
-	UPointLightComponent* PointLight;
 
 	ELastMoveDirection LastDirection = ELastMoveDirection::LMD_None;
 	ELastMoveDirection PreviousDirection = ELastMoveDirection::LMD_None;


### PR DESCRIPTION
## New Features

- Add Niagara System particle effect for the lantern flame and place it at the lantern. This moves around when the character changes direction
- Add a light function material to mimic the flickering of a flame from the lantern
- Update positioning of the light to better represent the lantern placement

https://github.com/Distance-Over-Time/Hereafter/assets/20312973/9432b041-71f9-493d-b2de-2bc4445a35d0

## Bug Fixes

- Fix a bug with the UI/Menus not adjusting to different screen sizes/resolutions
- Fix a bug where the keyboard inputs would not immediately work in the pause menu. You first had to click into the screen to get the inputs to work
- Add some base user settings in `GameUserSettings.ini` where the game should start in windowed full screen and adjust to their screen resolution